### PR TITLE
7 map tokens to prompts and positions

### DIFF
--- a/tinyevals/dataset.py
+++ b/tinyevals/dataset.py
@@ -1,3 +1,4 @@
+import numpy as np
 from datasets import load_dataset
 from tqdm.auto import tqdm
 
@@ -9,3 +10,12 @@ def load_clean_dataset(split: str, tokenized: bool = False) -> list[str]:
     for sample in tqdm(hf_ds["tokens" if tokenized else "story"]):
         dataset.append(sample)
     return dataset
+
+def token_map(tokenized_dataset: list[str]) -> dict[int, list[tuple[int, int]]]:
+    unique_tokens = np.unique(tokenized_dataset)
+    mapping = {}
+    for token in tqdm(unique_tokens):
+        indices = np.where(tokenized_dataset == token)
+        mapping[token] = list(zip(*indices))
+
+    return mapping

--- a/tinyevals/dataset.py
+++ b/tinyevals/dataset.py
@@ -11,7 +11,7 @@ def load_clean_dataset(split: str, tokenized: bool = False) -> list[str]:
         dataset.append(sample)
     return dataset
 
-def token_map(tokenized_dataset: list[str]) -> dict[int, list[tuple[int, int]]]:
+def token_map(tokenized_dataset: list[list[int]]) -> dict[int, list[tuple[int, int]]]:
     unique_tokens = np.unique(tokenized_dataset)
     mapping = {}
     for token in tqdm(unique_tokens):

--- a/tinyevals/dataset.py
+++ b/tinyevals/dataset.py
@@ -4,8 +4,8 @@ from tqdm.auto import tqdm
 def load_clean_dataset(split: str, tokenized: bool = False) -> list[str]:
     # checking just startswith, because you can include slice like "train[:1000]"
     assert split.startswith("train") or split.startswith("validation")
-    hf_ds = load_dataset(f"jbrinkma/tinystories-v2-clean{'-tokenized' if tokenized else ''}")
+    hf_ds = load_dataset(f"jbrinkma/tinystories-v2-clean{'-tokenized' if tokenized else ''}", split=split)
     dataset = []
-    for sample_txt in tqdm(hf_ds["tokens" if tokenized else "text"]):
-        dataset.append(sample_txt)
+    for sample in tqdm(hf_ds["tokens" if tokenized else "story"]):
+        dataset.append(sample)
     return dataset

--- a/tinyevals/dataset.py
+++ b/tinyevals/dataset.py
@@ -18,8 +18,3 @@ def token_map(tokenized_dataset: list[list[int]]) -> dict[int, list[tuple[int, i
             mapping.setdefault(token, []).append((prompt_idx, token_idx))
 
     return mapping
-
-if __name__ == "__main__":
-    tk = load_clean_dataset("train[:10]", True)
-    mapping = token_map(tk)
-    print(mapping)

--- a/tinyevals/dataset.py
+++ b/tinyevals/dataset.py
@@ -1,4 +1,3 @@
-import numpy as np
 from datasets import load_dataset
 from tqdm.auto import tqdm
 
@@ -12,10 +11,15 @@ def load_clean_dataset(split: str, tokenized: bool = False) -> list[str]:
     return dataset
 
 def token_map(tokenized_dataset: list[list[int]]) -> dict[int, list[tuple[int, int]]]:
-    unique_tokens = np.unique(tokenized_dataset)
     mapping = {}
-    for token in tqdm(unique_tokens):
-        indices = np.where(tokenized_dataset == token)
-        mapping[token] = list(zip(*indices))
+
+    for prompt_idx, prompt in enumerate(tokenized_dataset):
+        for token_idx, token in enumerate(prompt):
+            mapping.setdefault(token, []).append((prompt_idx, token_idx))
 
     return mapping
+
+if __name__ == "__main__":
+    tk = load_clean_dataset("train[:10]", True)
+    mapping = token_map(tk)
+    print(mapping)


### PR DESCRIPTION
Added function `token_map` to map each unique tokens in a tokenized dataset to a list of tuples (prompt, position) for that token. I imported `numpy` for the cleaner code with `np.where`.

This PR is for the issue #7 